### PR TITLE
Remove hacky share_on_mastodon_toot_args filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Those adjustments (a) remove the display of a title for the note post type and (
   * Improve transformation of paragraph blocks.
   * Improve extraction of anchor hrefs from markup.
 * Properly reply to a previous note's corresponding Mastodon post.
+* Remove hacky filtering of Share on Mastodon.
+  * This is technically a back-compat break for Share on Mastodon <0.9.
 * Update `@wordpress/scripts` dependency to 25.5.1.
 
 ### 1.4.0

--- a/includes/share-on-mastodon.php
+++ b/includes/share-on-mastodon.php
@@ -10,6 +10,7 @@ namespace ShortNotes\ShareOnMastodon;
 use Shortnotes\PostType\Note;
 
 add_filter( 'share_on_mastodon_status', __NAMESPACE__ . '\filter_status_text', 10, 2 );
+add_filter( 'share_on_mastodon_toot_args', __NAMESPACE__ . '\filter_args', 10, 2 );
 
 /**
  * Filter Mastodon toot args to include a reply to ID if it exists.
@@ -114,13 +115,6 @@ function get_reply_to_id( string $url ) : int {
  */
 function filter_status_text( string $status, \WP_Post $post ): string {
 	$status = transform_content( $post->post_content );
-
-	add_filter(
-		'share_on_mastodon_toot_args',
-		function( $args ) use ( $post ) {
-			return filter_args( $args, $post );
-		}
-	);
 
 	return $status;
 }


### PR DESCRIPTION
`$post` is passed as of Share on Mastodon 0.9.0, so we can remove the hacky-ish just in time filtering that I was doing.

If one of the 2 or 3 people that use Shortnotes is also on a Share on Mastodon version earlier than 0.9.0, they should please update both plugins. :)