### PR TITLE
Fix handling of the quote block

### DIFF
--- a/includes/post-type-note.php
+++ b/includes/post-type-note.php
@@ -207,6 +207,9 @@ function get_placeholder_title() {
 function generate_sub_title( string $html ): string {
 	$sub_title = wp_strip_all_tags( $html );
 
+	// Stripe newline characters.
+	$sub_title = str_replace( array( "\r", "\n" ), '', $sub_title );
+
 	// At the risk of being complicated, determine the length of the translated "Note" pretext so
 	// that we can build a maximum string of 50 characters.
 	$string_lenth = 50 - strlen( get_placeholder_title() );
@@ -242,7 +245,7 @@ function get_formatted_title( array $post_data ): string {
 			// A paragraph has been found, we're moving on and using it for the title.
 			break;
 		} elseif ( 'core/quote' === $block['blockName'] ) {
-			$sub_title = transform_content( $post_data['post_content'] );
+			$sub_title = generate_sub_title( '&ldquo;' . trim( $post_data['post_content'] ) );
 
 			// A quote has been found, use its plain text equivalent and move on.
 			break;

--- a/includes/post-type-note.php
+++ b/includes/post-type-note.php
@@ -459,9 +459,13 @@ function transform_block( array $block ): string {
 			$content .= transform_block( $inner_block );
 		}
 
-		// Quotes use a dash before the citation is appended.
-		$content .= '” - ';
-		$content .= strip_html( trim( $block['innerHTML'] ) );
+		$citation = trim( ltrim( trim( strip_html( $block['innerHTML'] ) ), '-' ) );
+
+		if ( '' !== $citation ) {
+			$content .= '” - ' . $citation;
+		} else {
+			$content .= '”';
+		}
 	} elseif ( 'core/embed' === $block['blockName'] ) {
 		$content .= $block['attrs']['url'] ?? '';
 	} else {

--- a/includes/post-type-note.php
+++ b/includes/post-type-note.php
@@ -456,7 +456,16 @@ function transform_block( array $block ): string {
 		$content .= '“';
 
 		foreach ( $block['innerBlocks'] as $inner_block ) {
-			$content .= transform_block( $inner_block );
+			// Strip leading and trailing double quotation marks.
+			$content .= html_entity_decode(
+				preg_replace(
+					'/^(&quot;|&ldquo;|&rdquo;)|(&quot;|&ldquo;|&rdquo;)$/',
+					'',
+					htmlentities(
+						transform_block( $inner_block )
+					)
+				),
+			);
 		}
 
 		$citation = trim( ltrim( trim( strip_html( $block['innerHTML'] ) ), '-' ) );

--- a/tests/test-post-type-note.php
+++ b/tests/test-post-type-note.php
@@ -156,6 +156,26 @@ Have to do -----</pre>
 	}
 
 	/**
+	 * If a dash is prepended to a citation already, Shortnotes should not add another.
+	 */
+	public function test_convert_quote_block_with_dash_in_citation() {
+		ob_start();
+		?>
+		<!-- wp:quote -->
+		<blockquote class="wp-block-quote"><!-- wp:paragraph -->
+		<p>I am not confident enough in the solution to summon the future energy it may require to defend the change after all of the work has been done.</p>
+		<!-- /wp:paragraph --><cite>- Me, <a href="https://jeremyfelt.com/2020/04/24/thoughts-for-the-weeks-end-18/">3 years ago</a>, on open source maintenance</cite></blockquote>
+		<!-- /wp:quote -->
+		<?php
+		$pre_html = ob_get_clean();
+
+		$expected_text    = '“I am not confident enough in the solution to summon the future energy it may require to defend the change after all of the work has been done.” - Me, 3 years ago, on open source maintenance https://jeremyfelt.com/2020/04/24/thoughts-for-the-weeks-end-18/';
+		$transformed_text = Note\transform_content( $pre_html );
+
+		$this->assertEquals( $expected_text, $transformed_text );
+	}
+
+	/**
 	 * An embedded video should transform to a link to the video.
 	 */
 	public function test_convert_single_video_embed_block_to_url() {

--- a/tests/test-post-type-note.php
+++ b/tests/test-post-type-note.php
@@ -195,6 +195,25 @@ https://www.youtube.com/watch?v=5NPBIwQyPWE
 	}
 
 	/**
+	 * A note with a quote that starts with double quotes should trim the extra double quotes.
+	 */
+	public function test_convert_trim_extra_double_quotes_from_note() {
+		ob_start();
+		?>
+		<!-- wp:quote -->
+<blockquote class="wp-block-quote"><!-- wp:paragraph -->
+<p>"A quote in a note that starts and ends with a double quote character that should be removed because we add a double quote character."</p>
+<!-- /wp:paragraph --><cite>A test name</cite></blockquote>
+<!-- /wp:quote -->
+		<?php
+		$pre_html         = ob_get_clean();
+		$expected_text    = '“A quote in a note that starts and ends with a double quote character that should be removed because we add a double quote character.” - A test name';
+		$transformed_text = Note\transform_content( $pre_html );
+
+		$this->assertEquals( $expected_text, $transformed_text );
+	}
+
+	/**
 	 * A note with a single paragraph should have a title that starts with the paragraph text.
 	 */
 	public function test_generated_title_note_has_single_paragraph_block() {

--- a/tests/test-post-type-note.php
+++ b/tests/test-post-type-note.php
@@ -173,4 +173,58 @@ https://www.youtube.com/watch?v=5NPBIwQyPWE
 
 		$this->assertEquals( $expected_text, $transformed_text );
 	}
+
+	/**
+	 * A note with a single paragraph should have a title that starts with the paragraph text.
+	 */
+	public function test_generated_title_note_has_single_paragraph_block() {
+		ob_start();
+		?>
+		<!-- wp:paragraph -->
+		<p>Somebody should do the intro to Psycho as a web page</p>
+		<!-- /wp:paragraph -->
+		<?php
+		$content = ob_get_clean();
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => Note\get_slug(),
+				'post_content' => $content,
+				'post_status'  => 'publish',
+			]
+		);
+
+		$this->assertEquals( 'Note: Somebody should do the intro to Psycho as a we&hellip;', get_the_title( $post_id ) );
+	}
+
+	/**
+	 * A note that begins with a quote block should have a title that starts with the quote text.
+	 */
+	public function test_generated_title_note_begins_with_quote_block() {
+		ob_start();
+		?>
+		<!-- wp:quote -->
+<blockquote class="wp-block-quote"><!-- wp:paragraph -->
+<p>I am not confident enough in the solution to summon the future energy it may require to defend the change after all of the work has been done.</p>
+<!-- /wp:paragraph --><cite>- Me, <a href="https://jeremyfelt.com/2020/04/24/thoughts-for-the-weeks-end-18/">3 years ago</a>, on open source maintenance</cite></blockquote>
+<!-- /wp:quote -->
+
+<!-- wp:paragraph -->
+<p>I ran into this again, so I wrote this note so that I would run into it again.</p>
+<!-- /wp:paragraph -->
+		<?php
+		$content = ob_get_clean();
+
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'    => Note\get_slug(),
+				'post_content' => $content,
+				'post_status'  => 'publish',
+			]
+		);
+
+		$post = get_post( $post_id );
+
+		$this->assertEquals( 'Note: &ldquo;I am not confident enough in the soluti&hellip;', $post->post_title );
+	}
 }


### PR DESCRIPTION
* Improve title generation when a note starts with a quote.
* Avoid duplicate dashes when a note with a quote is transformed for Mastodon.
* Remove leading and trailing double quotes of all flavors when a note with a quote is transformed for Mastodon.

Fixes #32.
Fixes #34.