### PR TITLE
Do not attempt to modify content if no global post is available

### DIFF
--- a/includes/post-type-note.php
+++ b/includes/post-type-note.php
@@ -379,7 +379,14 @@ function prepend_reply_to_markup( string $content ): string {
 		return $content;
 	}
 
-	$current_post    = get_post();
+	$current_post = get_post();
+
+	// We can only adjust content with context, which WordPress does not
+	// guarantee when filtering `the_content`.
+	if ( ! $current_post ) {
+		return $content;
+	}
+
 	$reply_to_markup = get_reply_to_markup( $current_post );
 
 	$content = $reply_to_markup . $content;


### PR DESCRIPTION
When `get_the_excerpt()` is called with an explicit `$post`, that post is passed as context to the `get_the_excerpt` filter.

Even though `wp_trim_excerpt` receives the `$post` as an argument, it does not provide that as context when applying `the_content` to the post content.

In this case, and probably other related cases, a fatal error would be generated because the global `$post` data we rely on is not available.

A future commit may also account for a second parameter passed to `the_content`, but I'll think that through some more. :)

See #44