### PR TITLE
Indicate support for WP 6.8.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: jeremyfelt
 Tags: indieweb, notes, replies, short
 Requires at least: 5.6
-Tested up to: 6.4
+Tested up to: 6.7
 Stable tag: 1.6.2
 License: GPLv2 or Later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: jeremyfelt
 Tags: indieweb, notes, replies, short
 Requires at least: 5.6
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 1.6.2
 License: GPLv2 or Later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Good news! It still works.

Updates the WP supported version. At the moment, the wordpress.org plugin repo page is no-indexed so finding the plugin download link is a bit difficult as it's easy to end up on wordpress.com.